### PR TITLE
Extract repository Service from the actions package.

### DIFF
--- a/actions/rebuild.go
+++ b/actions/rebuild.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"github.com/knakk/rdf"
 	"github.com/sul-dlss-labs/rialto-derivatives/message"
 	"github.com/sul-dlss-labs/rialto-derivatives/models"
 	"github.com/sul-dlss-labs/rialto-derivatives/runtime"
@@ -34,45 +33,9 @@ func (r *RebuildAction) Run(message *message.Message) error {
 
 // Return a list of resources populated by querying for everything in the triplestore
 func (r *RebuildAction) queryResources() ([]models.Resource, error) {
-	response, err := r.registry.Canonical.QueryEverything()
+	list, err := r.registry.Canonical.AllResources()
 	if err != nil {
 		return nil, err
 	}
-	// Solutions look like this:
-	// [map[o:AA00 s:http://rialto.stanford.edu/stanford p:http://rialto.stanford.edu/vocab/organizationCodes]]
-	// log.Printf("Solutions %s", response.Solutions())
-	list := r.toResourceList(r.groupBySubject(response.Solutions()))
 	return list, nil
-}
-
-func (r *RebuildAction) toResourceList(grouped map[string]map[string][]rdf.Term) []models.Resource {
-	list := []models.Resource{}
-	for subject, predicates := range grouped {
-		list = append(list, models.NewResource(subject, predicates))
-	}
-	return list
-}
-
-// Returns a map with subjects as keys and a map with predicates as values
-func (r *RebuildAction) groupBySubject(raw []map[string]rdf.Term) map[string]map[string][]rdf.Term {
-	result := map[string]map[string][]rdf.Term{}
-	for _, triple := range raw {
-		// Subjects and Predicates are always IRIs so it's safe to cast to String
-		subject := triple["s"].String()
-		predicate := triple["p"].String()
-		object := triple["o"]
-
-		if result[subject] == nil {
-			// The first time we encounter a subject
-			result[subject] = map[string][]rdf.Term{}
-		}
-		if result[subject][predicate] == nil {
-			// First time we encounter a predicate
-			result[subject][predicate] = []rdf.Term{object}
-		} else {
-			// subsequent encounters
-			result[subject][predicate] = append(result[subject][predicate], object)
-		}
-	}
-	return result
 }

--- a/actions/rebuild_test.go
+++ b/actions/rebuild_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/sul-dlss-labs/rialto-derivatives/message"
+	"github.com/sul-dlss-labs/rialto-derivatives/repository"
 	"github.com/sul-dlss-labs/rialto-derivatives/runtime"
 	"github.com/vanng822/go-solr/solr"
 )
@@ -43,7 +44,7 @@ func TestRebuildRepository(t *testing.T) {
 	fakeSparql := new(MockedReader)
 	reg := &runtime.Registry{
 		Derivatives: fakeSolr,
-		Canonical:   fakeSparql,
+		Canonical:   repository.NewService(fakeSparql),
 	}
 	action := NewRebuildAction(reg)
 	err := action.Run(msg)

--- a/actions/touch.go
+++ b/actions/touch.go
@@ -3,7 +3,6 @@ package actions
 import (
 	"log"
 
-	"github.com/knakk/rdf"
 	"github.com/sul-dlss-labs/rialto-derivatives/message"
 	"github.com/sul-dlss-labs/rialto-derivatives/models"
 	"github.com/sul-dlss-labs/rialto-derivatives/runtime"
@@ -43,23 +42,5 @@ func (r *TouchAction) Run(message *message.Message) error {
 // This will take an SNS message and retrieve a resource from Neptune
 func (r *TouchAction) recordToResource(msg *message.Message) (*models.Resource, error) {
 	subject := msg.Entities[0]
-	response, err := r.registry.Canonical.QueryByID(subject)
-	if err != nil {
-		return nil, err
-	}
-	data := map[string][]rdf.Term{}
-	for _, triple := range response.Solutions() {
-		predicate := triple["p"].String()
-		object := triple["o"]
-
-		if data[predicate] == nil {
-			// First time we encounter a predicate
-			data[predicate] = []rdf.Term{object}
-		} else {
-			// subsequent encounters
-			data[predicate] = append(data[predicate], object)
-		}
-	}
-	resource := models.NewResource(subject, data)
-	return &resource, nil
+	return r.registry.Canonical.SubjectToResource(subject)
 }

--- a/actions/touch_test.go
+++ b/actions/touch_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/sul-dlss-labs/rialto-derivatives/message"
+	"github.com/sul-dlss-labs/rialto-derivatives/repository"
 	"github.com/sul-dlss-labs/rialto-derivatives/runtime"
 )
 
@@ -12,7 +13,7 @@ func TestRecordToResource(t *testing.T) {
 	fakeSparql := new(MockedReader)
 
 	reg := &runtime.Registry{
-		Canonical: fakeSparql,
+		Canonical: repository.NewService(fakeSparql),
 	}
 	msg := &message.Message{Entities: []string{"http://example.com/record2"}}
 	action := NewTouchAction(reg)

--- a/repository/reader.go
+++ b/repository/reader.go
@@ -1,6 +1,8 @@
 package repository
 
-import "github.com/knakk/sparql"
+import (
+	"github.com/knakk/sparql"
+)
 
 // Reader reads from the data store
 type Reader interface {

--- a/repository/service.go
+++ b/repository/service.go
@@ -1,0 +1,84 @@
+package repository
+
+import (
+	"github.com/knakk/rdf"
+	"github.com/sul-dlss-labs/rialto-derivatives/models"
+)
+
+// Service is the main component of the repository
+type Service struct {
+	reader Reader
+}
+
+// NewService creates a new Service instance
+func NewService(reader Reader) *Service {
+	return &Service{reader: reader}
+}
+
+// SubjectToResource takes a subject string and returns a resource
+func (m *Service) SubjectToResource(subject string) (*models.Resource, error) {
+	response, err := m.reader.QueryByID(subject)
+	if err != nil {
+		return nil, err
+	}
+	data := map[string][]rdf.Term{}
+	for _, triple := range response.Solutions() {
+		predicate := triple["p"].String()
+		object := triple["o"]
+
+		if data[predicate] == nil {
+			// First time we encounter a predicate
+			data[predicate] = []rdf.Term{object}
+		} else {
+			// subsequent encounters
+			data[predicate] = append(data[predicate], object)
+		}
+	}
+	resource := models.NewResource(subject, data)
+	return &resource, nil
+}
+
+// AllResources returns a full list of resources
+func (m *Service) AllResources() ([]models.Resource, error) {
+	response, err := m.reader.QueryEverything()
+	if err != nil {
+		return nil, err
+	}
+	// Solutions look like this:
+	// [map[o:AA00 s:http://rialto.stanford.edu/stanford p:http://rialto.stanford.edu/vocab/organizationCodes]]
+	// log.Printf("Solutions %s", response.Solutions())
+	list := m.toResourceList(m.groupBySubject(response.Solutions()))
+	return list, nil
+}
+
+func (m *Service) toResourceList(grouped map[string]map[string][]rdf.Term) []models.Resource {
+	list := []models.Resource{}
+	for subject, predicates := range grouped {
+		list = append(list, models.NewResource(subject, predicates))
+	}
+	return list
+}
+
+// Returns a map with subjects as keys and a map with predicates as values
+func (m *Service) groupBySubject(raw []map[string]rdf.Term) map[string]map[string][]rdf.Term {
+	result := map[string]map[string][]rdf.Term{}
+	for _, triple := range raw {
+		// Subjects and Predicates are always IRIs so it's safe to cast to String
+		subject := triple["s"].String()
+		predicate := triple["p"].String()
+		object := triple["o"]
+
+		if result[subject] == nil {
+			// The first time we encounter a subject
+			result[subject] = map[string][]rdf.Term{}
+		}
+		if result[subject][predicate] == nil {
+			// First time we encounter a predicate
+			result[subject][predicate] = []rdf.Term{object}
+		} else {
+			// subsequent encounters
+			result[subject][predicate] = append(result[subject][predicate], object)
+		}
+	}
+	return result
+}

--- a/runtime/registry.go
+++ b/runtime/registry.go
@@ -10,7 +10,7 @@ import (
 type Registry struct {
 	Derivatives derivative.Writer
 	Indexer     *transform.CompositeIndexer
-	Canonical   repository.Reader
+	Canonical   *repository.Service
 }
 
 // NewRegistry creates a new instance of the service registry
@@ -18,6 +18,6 @@ func NewRegistry(solr derivative.Writer, indexer *transform.CompositeIndexer, sp
 	return &Registry{
 		Derivatives: solr,
 		Indexer:     indexer,
-		Canonical:   sparql,
+		Canonical:   repository.NewService(sparql),
 	}
 }


### PR DESCRIPTION
The actions package shouldn't have to know anything about rdf.

This will enable indexers of Publications, to call the service when they encounter a URI for an Agent they want to index. 