### PR TITLE
Final ci fix - set AWS session

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,3 +82,17 @@ jobs:
             aws configure set default.output json
             aws configure list  # Get confirmation it worked in your logs
             aws lambda update-function-code --function-name rialto-derivatives-postgres-development --zip-file fileb://lambda.zip
+
+workflows:
+  version: 2
+  
+  deploy-dev:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore: master
+      - deploy:
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,18 +70,15 @@ jobs:
       - run:
           name: Update Lambda Function
           command: |
+            unset  AWS_SESSION_TOKEN
+            temp_role=$(aws sts assume-role \
+                  --role-session-name "DevelopersRole" \
+                  --role-arn $DEV_ROLE_ARN \
+                  --profile rialto)
+            export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)
+            export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
+            export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)
+            aws configure set region $AWS_REGION
+            aws configure set default.output json
+            aws configure list  # Get confirmation it worked in your logs
             aws lambda update-function-code --function-name rialto-derivatives-postgres-development --zip-file fileb://lambda.zip
-
-workflows:
-  version: 2
-  
-  deploy-dev:
-    jobs:
-      - build:
-          filters:
-            branches:
-              ignore: master
-      - deploy:
-          filters:
-            branches:
-              only: master


### PR DESCRIPTION
Sorry - this should be the last fix. Apparently the system is persistent (complains about .aws existing) but the session needs to be reestablished on the second deployment. This isn't super easy to test because it requires a merge to master, apologies.

