### PR TITLE
Store name as a text field

### DIFF
--- a/transform/person_indexer.go
+++ b/transform/person_indexer.go
@@ -25,7 +25,7 @@ func (m *PersonIndexer) Index(resource *models.Person, doc solr.Document) solr.D
 	doc.Set("type_ssi", "Person")
 
 	// 1. Get the associated name resource
-	doc.Set("name_ssim", m.retrieveAssociatedName(resource))
+	doc.Set("name_tsim", m.retrieveAssociatedName(resource))
 
 	// 2. department
 	doc.Set("department_label_ssim", resource.DepartmentLabel)

--- a/transform/person_indexer_test.go
+++ b/transform/person_indexer_test.go
@@ -95,7 +95,7 @@ func TestPersonResourceWithName(t *testing.T) {
 	in := make(solr.Document)
 	doc := indexer.Index(resource, in)
 
-	assert.Equal(t, "Harry Potter", doc.Get("name_ssim"))
+	assert.Equal(t, "Harry Potter", doc.Get("name_tsim"))
 }
 
 func TestPersonWithoutDepartment(t *testing.T) {
@@ -109,5 +109,5 @@ func TestPersonWithoutDepartment(t *testing.T) {
 	in := make(solr.Document)
 	doc := indexer.Index(resource, in)
 
-	assert.Equal(t, "Hermione Granger", doc.Get("name_ssim"))
+	assert.Equal(t, "Hermione Granger", doc.Get("name_tsim"))
 }


### PR DESCRIPTION
So that we can search by a part (e.g. last name).  This will tokenize
the field on word boundaries, but not do word stemming.