### PR TITLE
Consistently use the sparql field name

### DIFF
--- a/models/person.go
+++ b/models/person.go
@@ -34,7 +34,7 @@ func NewPerson(data map[string]rdf.Term) *Person {
 		obj.Lastname = lastname.String()
 	}
 
-	if organization := data["organization"]; organization != nil {
+	if organization := data["org"]; organization != nil {
 		str := organization.String()
 		obj.Organization = &str
 	}

--- a/models/person_test.go
+++ b/models/person_test.go
@@ -34,7 +34,7 @@ func TestNewPersonAllFields(t *testing.T) {
 	data["subtype"] = faculty
 	data["lastname"] = lname
 	data["firstname"] = fname
-	data["organization"] = organization
+	data["org"] = organization
 
 	resource := NewPerson(data)
 	assert.IsType(t, &Person{}, resource)
@@ -53,7 +53,7 @@ func TestSetOrganizationInfo(t *testing.T) {
 
 	data["id"] = id
 	data["subtype"] = faculty
-	data["organization"] = organization
+	data["org"] = organization
 
 	resource := NewPerson(data)
 


### PR DESCRIPTION
The query in repository/service.go was using `?org` as the variable
name, but the NewPerson method was asking for `organization`.  Now they
are consistent.