### PR TITLE
Make ToConnString a public method

### DIFF
--- a/derivative/postgres_client.go
+++ b/derivative/postgres_client.go
@@ -21,7 +21,7 @@ type PostgresClient struct {
 
 // NewPostgresClient returns a new PostgresClient instance
 func NewPostgresClient(config *PostgresConfig, repo repository.Repository) *PostgresClient {
-	db, err := sql.Open("postgres", config.toConnString())
+	db, err := sql.Open("postgres", config.ToConnString())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/derivative/postgres_config.go
+++ b/derivative/postgres_config.go
@@ -17,7 +17,8 @@ func NewPostgresConfig() *PostgresConfig {
 	return &PostgresConfig{SSL: true}
 }
 
-func (c *PostgresConfig) toConnString() string {
+// ToConnString casts the config to a connection string
+func (c *PostgresConfig) ToConnString() string {
 	var b bytes.Buffer
 	if c.User != nil {
 		b.WriteString("user=")

--- a/derivative/postgres_config_test.go
+++ b/derivative/postgres_config_test.go
@@ -15,7 +15,7 @@ func TestPostgresConfig(t *testing.T) {
 		WithUser("rialto").
 		WithPassword("seckret")
 
-	assert.Equal(t, conf.toConnString(), "user=rialto host=123.45.67.89 port=5479 dbname=my_instance password=seckret ")
+	assert.Equal(t, conf.ToConnString(), "user=rialto host=123.45.67.89 port=5479 dbname=my_instance password=seckret ")
 }
 
 func TestPostgresConfigWithSSLDisabled(t *testing.T) {
@@ -23,5 +23,5 @@ func TestPostgresConfigWithSSLDisabled(t *testing.T) {
 		WithSSL(false).
 		WithDbname("my_instance")
 
-	assert.Equal(t, conf.toConnString(), "dbname=my_instance sslmode=disable")
+	assert.Equal(t, conf.ToConnString(), "dbname=my_instance sslmode=disable")
 }


### PR DESCRIPTION
So we can reuse it in rialto-trigger-rebuild